### PR TITLE
Return tweak alongside public key in derive method

### DIFF
--- a/src/derivation/mod.rs
+++ b/src/derivation/mod.rs
@@ -11,7 +11,15 @@ use std::{
     fmt,
 };
 
-use super::key::{mk_public_key, mk_xprv, mk_xpub, XPrv, XPub, XPRV_SIZE, XPUB_SIZE};
+use super::key::{
+    mk_public_key,
+    mk_xprv,
+    mk_xpub,
+    XPrv,
+    XPub,
+    XPRV_SIZE,
+    XPUB_SIZE,
+    DerivationResult};
 pub use common::{DerivationIndex, DerivationScheme, DerivationType};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,7 +142,7 @@ pub fn public(
     xpub: &XPub,
     index: DerivationIndex,
     scheme: DerivationScheme,
-) -> Result<XPub, DerivationError> {
+) -> Result<DerivationResult, DerivationError> {
     let pk = <&[u8; 32]>::try_from(&xpub.as_ref()[0..32]).unwrap();
     let chaincode = &xpub.as_ref()[32..64];
 
@@ -173,7 +181,10 @@ pub fn public(
     imac.reset();
     zmac.reset();
 
-    Ok(XPub::from_bytes(out))
+    Ok(DerivationResult {
+        pub_key: XPub::from_bytes(out),
+        tweak: left.try_into().unwrap(),
+    })
 }
 
 impl fmt::Display for DerivationError {

--- a/src/key.rs
+++ b/src/key.rs
@@ -41,6 +41,12 @@ pub enum PublicKeyError {
     LengthInvalid(usize),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivationResult {
+    pub pub_key: XPub,
+    pub tweak: [u8; PUBLIC_KEY_SIZE],
+}
+
 /// HDWallet extended private key
 ///
 /// Effectively this is an ed25519 extended secret key (64 bytes) followed by a chain code (32 bytes).
@@ -314,7 +320,7 @@ impl XPub {
         &self,
         scheme: DerivationScheme,
         index: DerivationIndex,
-    ) -> Result<Self, DerivationError> {
+    ) -> Result<DerivationResult, DerivationError> {
         derivation::public(self, index, scheme)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,5 @@ mod tests;
 mod bench;
 
 pub use derivation::{DerivationError, DerivationIndex, DerivationScheme};
-pub use key::{PrivateKeyError, PublicKeyError, XPrv, XPub, XPRV_SIZE, XPUB_SIZE};
+pub use key::{PrivateKeyError, PublicKeyError, XPrv, XPub, XPRV_SIZE, XPUB_SIZE, DerivationResult};
 pub use signature::{Signature, SignatureError, SIGNATURE_SIZE};


### PR DESCRIPTION
In some applications of HD key derivation, the left part of the hash is required for further operations. This PR changes the derivation method to return that alongside the child key.